### PR TITLE
Fix build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-tauri:
+  build-tauri:
     permissions:
       contents: write
     strategy:
@@ -53,9 +53,13 @@ jobs:
         with:
           args: ${{ matrix.args }}
 
+      - name: Show artifacts
+        run: |
+          echo ${{ steps.tauri-action.outputs.artifacts }}
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: tauri-action
-          path: ${{ join(fromJSON(steps.tauri.outputs.artifacts), '\n') }}
+          path: ${{ join(fromJSON(steps.tauri-action.outputs.artifacts), '\n') }}
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,5 +61,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tauri-action
-          path: ${{ join(fromJSON(steps.tauri-action.outputs.artifactPaths), '\n') }}
+          path: ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[0] }}
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,12 @@ jobs:
         include:
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
             args: '--target aarch64-apple-darwin'
-          # - platform: 'macos-latest' # for Intel based macs.
-          #   args: '--target x86_64-apple-darwin'
-          # - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
-          #   args: ''
-          # - platform: 'windows-latest'
-          #   args: ''
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -60,6 +60,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: tauri-action
+          name: EnzymeMLSuite-${{ matrix.platform }}
           path: ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[0] }}
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,12 @@ jobs:
         include:
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
             args: '--target aarch64-apple-darwin'
-          - platform: 'macos-latest' # for Intel based macs.
-            args: '--target x86_64-apple-darwin'
-          - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
-            args: ''
-          - platform: 'windows-latest'
-            args: ''
+          # - platform: 'macos-latest' # for Intel based macs.
+          #   args: '--target x86_64-apple-darwin'
+          # - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+          #   args: ''
+          # - platform: 'windows-latest'
+          #   args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,11 +55,11 @@ jobs:
 
       - name: Show artifacts
         run: |
-          echo ${{ steps.tauri-action.outputs.artifacts }}
+          echo ${{ steps.tauri-action.outputs.artifactPaths }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: tauri-action
-          path: ${{ join(fromJSON(steps.tauri-action.outputs.artifacts), '\n') }}
+          path: ${{ join(fromJSON(steps.tauri-action.outputs.artifactPaths), '\n') }}
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,5 +57,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tauri-action
-          path: ${{ steps.tauri-action.outputs.artifactPaths }}
+          path: ${{ join(fromJSON(steps.tauri.outputs.artifacts), '\n') }}
           if-no-files-found: error

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
     "distDir": "../dist"
   },
   "package": {
-    "productName": "EnzymeMLSuite",
+    "productName": "EnzymeML Suite",
     "version": "0.1.0"
   },
   "tauri": {
@@ -45,7 +45,7 @@
     "bundle": {
       "active": true,
       "targets": "all",
-      "identifier": "enzymeml",
+      "identifier": "enzymeml-suite",
       "icon": [
         "icons/32x32.png",
         "icons/128x128.png",


### PR DESCRIPTION
This pull request updates the build workflow and configuration to improve artifact handling and clarify naming conventions for the Tauri application. The main changes include renaming jobs for clarity, updating artifact upload logic, and refining the application identifier.

**Build workflow improvements:**

* Renamed the workflow job from `publish-tauri` to `build-tauri` in `.github/workflows/build.yaml` for clearer job purpose.
* Added a step to display artifact paths after the Tauri build step, aiding in debugging and visibility of build outputs.
* Updated the artifact upload step to use a platform-specific name (`EnzymeMLSuite-${{ matrix.platform }}`) and to upload only the first artifact path, improving artifact management and clarity.

**Configuration update:**

* Changed the Tauri bundle identifier from `enzymeml` to `enzymeml-suite` in `src-tauri/tauri.conf.json` to reflect the suite's branding more accurately.