### PR TITLE
Fix `MeasurementForm` data unit handling and improve keyboard shortcuts

### DIFF
--- a/src-tauri/src/actions/smallmols.rs
+++ b/src-tauri/src/actions/smallmols.rs
@@ -177,7 +177,9 @@ pub fn list_small_mol_smiles(state: State<Arc<EnzymeMLState>>) -> HashMap<String
         .map(|s| {
             (
                 s.id.clone(),
-                s.canonical_smiles.clone().unwrap_or_else(|| s.id.clone()),
+                s.canonical_smiles
+                    .clone()
+                    .unwrap_or_else(|| "NO_SMILES".to_string()),
             )
         })
         .collect()

--- a/src/components/FileMenu.tsx
+++ b/src/components/FileMenu.tsx
@@ -281,7 +281,12 @@ export default function FileMenu() {
         switch (key) {
             // Open Document
             case 'open-from-file':
-                loadJSON();
+                loadJSON().then(() => {
+                    openNotification('Entry loaded', NotificationType.SUCCESS, 'Your entry has been loaded successfully');
+                    navigate('/');
+                }).catch((error) => {
+                    openNotification('Error loading entry', NotificationType.ERROR, error.toString());
+                });
                 break;
             case 'new':
                 newEntry().then(() => {

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -73,9 +73,16 @@ const items = [
 export default function MainMenu() {
   // States
   const darkMode = useAppStore((state) => state.darkMode);
+  const currentPath = useAppStore((state) => state.currentPath);
 
   // Styling
   const { token } = theme.useToken();
+
+  // Get the current menu key based on the current path
+  const getCurrentMenuKey = () => {
+    const currentItem = items.find((item) => item.route === currentPath);
+    return currentItem ? [currentItem.key] : [];
+  };
 
   // Handlers
   const navigate = useNavigate();
@@ -102,6 +109,7 @@ export default function MainMenu() {
       theme={darkMode ? "dark" : "light"}
       mode="vertical"
       items={items}
+      selectedKeys={getCurrentMenuKey()}
       onClick={handleMenuClick}
     />
   );

--- a/src/components/QuantityForm.tsx
+++ b/src/components/QuantityForm.tsx
@@ -10,16 +10,42 @@ import {
 
 import { getUnitGroups, UnitMap, UnitTypes } from "@commands/units.ts";
 
+/**
+ * Props interface for the QuantityForm component
+ */
 interface QuantityFormProps {
+  /** Form field name for the numeric value */
   name: string | (string | number)[];
+  /** Form field path for the unit object */
   unitPath: string | (string | number)[];
+  /** Label/placeholder text for the input field */
   label: string;
+  /** Array of unit types to filter available units */
   unitTypes: UnitTypes[];
+  /** Whether the field is required */
   required: boolean;
+  /** Callback function to handle object updates */
   handleUpdateObject: () => void;
+  /** Ant Design form instance */
   form: FormInstance;
 }
 
+/**
+ * QuantityForm component that provides a combined input for numeric values and their units
+ * 
+ * Features:
+ * - Numeric input field for quantity values
+ * - Unit selector with filtered options based on unit types
+ * - Automatic form synchronization with proper unit object storage
+ * - Support for both string and array-based form field paths
+ * 
+ * The component uses a dual approach for unit handling:
+ * - A hidden Form.Item stores the actual unit object
+ * - A visible Select acts as a proxy displaying unit names
+ * 
+ * @param props - The component props
+ * @returns JSX element containing the quantity form with numeric input and unit selector
+ */
 export default function QuantityForm({
   name,
   required,
@@ -30,11 +56,18 @@ export default function QuantityForm({
   form,
 }: QuantityFormProps) {
   // States
+  /** Available unit options for the select dropdown */
   const [unitOptions, setUnitOptions] = useState<SelectProps["options"]>([]);
+  /** Map of unit names to unit objects */
   const [unitMap, setUnitMap] = useState<UnitMap>({});
+  /** Currently selected unit name (for display purposes) */
   const [selectedUnit, setSelectedUnit] = useState<string | null>(null);
 
-  // Effects: Fetch unit options
+  // Effects
+  /**
+   * Fetches available unit options based on the provided unit types
+   * Also synchronizes the selected unit with the current form value
+   */
   useEffect(() => {
     getUnitGroups(unitTypes)
       .then((data) => {
@@ -47,8 +80,8 @@ export default function QuantityForm({
           }))
         );
 
-        // Effect: Set selected unit based on form values
-        // This is done, because the unit is not a string, but an object
+        // Synchronize selected unit with current form value
+        // This is necessary because the unit is stored as an object, not a string
         const currentUnit = form.getFieldValue(unitPath);
         const unitName = Object.entries(data).find(
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -66,6 +99,7 @@ export default function QuantityForm({
 
   return (
     <Space.Compact className={"w-full"}>
+      {/* Numeric input field for the quantity value */}
       <Form.Item noStyle name={name} rules={[{ required }]}>
         <InputNumber
           placeholder={label}
@@ -74,22 +108,28 @@ export default function QuantityForm({
         />
       </Form.Item>
 
-      {/* Hidden Form.Item that actually stores the value */}
-      {/* This is done, because the unit is not a string, but an object */}
+      {/* Hidden Form.Item that stores the actual unit object */}
+      {/* This approach is used because units are complex objects, not simple strings */}
       <Form.Item noStyle hidden name={unitPath} rules={[{ required }]} />
 
-      {/* Visible Select that acts as a proxy */}
-      {/* This select displays the unit options, but the value is the unit name */}
+      {/* Visible Select that acts as a proxy for unit selection */}
+      {/* Displays unit names but stores unit objects in the hidden form field */}
       <Select
         options={unitOptions}
         placeholder="Unit"
         value={selectedUnit}
         onChange={(value) => {
-          setSelectedUnit(value);
-          form.setFieldsValue({
-            [Array.isArray(unitPath) ? unitPath.join(".") : unitPath]:
-              unitMap[value],
-          });
+          setSelectedUnit(value)
+
+          // Handle both string and array-based field paths properly
+          if (Array.isArray(unitPath)) {
+            form.setFieldValue(unitPath, unitMap[value]);
+          } else {
+            form.setFieldsValue({
+              [unitPath]: unitMap[value],
+            });
+          }
+
           handleUpdateObject();
         }}
         style={{ width: "40%" }}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -108,7 +108,14 @@ export function useFileMenuShortcuts({
 }: FileMenuShortcuts, enabled: boolean = true) {
     const shortcuts = [];
 
-    const openHandler = onOpen || (() => loadJSON());
+    const openHandler = onOpen || (() => {
+        loadJSON().then(() => {
+            openNotification('Entry loaded', NotificationType.SUCCESS, 'Your entry has been loaded successfully');
+            navigate?.('/');
+        }).catch((error) => {
+            openNotification('Error loading entry', NotificationType.ERROR, error.toString());
+        });
+    });
     const exportHandler = onExport || (() => exportToJSON());
     const closeHandler = onClose || (() => appWindow.close());
 

--- a/src/measurements/MeasurementForm.tsx
+++ b/src/measurements/MeasurementForm.tsx
@@ -46,13 +46,8 @@ export default function MeasurementForm({
   // Add a debug wrapper for handleUpdateObject
   const handleUpdateMeasurement = React.useCallback(async () => {
     try {
-      console.log('Form data before update:', form.getFieldsValue());
-      console.log('Current data:', data);
-
       // Call the original handler
       await handleUpdateObject();
-
-      console.log('Update successful');
     } catch (error) {
       console.error('Update failed:', error);
     }
@@ -85,13 +80,16 @@ export default function MeasurementForm({
           field={field}
           subOpt={subOpt}
           availableSpecies={availableSpecies}
-          handleUpdateObject={handleUpdateObject}
+          handleUpdateObject={handleUpdateMeasurement}
           form={form}
         />
       ))}
       <Button
         type="dashed"
-        onClick={() => subOpt.add(handleAddSpecies())}
+        onClick={async () => {
+          const newSpecies = await handleAddSpecies();
+          subOpt.add(newSpecies);
+        }}
         block
       >
         + Add Species
@@ -130,7 +128,7 @@ export default function MeasurementForm({
           label={"Temperature"}
           unitTypes={[UnitTypes.TEMPERATURE]}
           required={false}
-          handleUpdateObject={handleUpdateObject}
+          handleUpdateObject={handleUpdateMeasurement}
           form={form}
         />
       </Form.Item>

--- a/src/measurements/components/InitialsField.tsx
+++ b/src/measurements/components/InitialsField.tsx
@@ -32,7 +32,7 @@ export default function InitialsField({
     <Row gutter={16} align="middle">
       <Col span={14}>
         <Form.Item
-          name={[field.key, "species_id"]}
+          name={[field.name, "species_id"]}
           style={{ marginBottom: 0 }}
         >
           <Select
@@ -45,8 +45,8 @@ export default function InitialsField({
       </Col>
       <Col span={8}>
         <QuantityForm
-          name={[field.key, "initial"]}
-          unitPath={[field.key, "data_unit"]}
+          name={[field.name, "initial"]}
+          unitPath={["species_data", field.name, "data_unit"]}
           label="Initial"
           unitTypes={[UnitTypes.CONCENTRATION]}
           required={false}

--- a/src/reactions/ReactionForm.tsx
+++ b/src/reactions/ReactionForm.tsx
@@ -54,6 +54,8 @@ export default function ReactionForm({ context }: FormViewProps<Reaction>) {
   >([]);
   /** SMILES string representation of the reaction for visual display */
   const [reactionSMILES, setReactionSMILES] = useState<string>("");
+  /** Whether there are small molecules with valid SMILES strings */
+  const [hasValidSmallMolecules, setHasValidSmallMolecules] = useState<boolean>(false);
 
   // Context
   const { handleUpdateObject, form, data, locked } = React.useContext(context);
@@ -102,7 +104,12 @@ export default function ReactionForm({ context }: FormViewProps<Reaction>) {
     const reactantIds = reactants.map((reactant) => reactant.species_id);
     const productIds = products.map((product) => product.species_id);
     listSmallMoleculesWithSMILES().then((smallMolecules) => {
-      setReactionSMILES(createReactionSMILES(reactantIds, productIds, smallMolecules));
+      const validSmallMolecules = Object.values(smallMolecules).filter((smiles) => smiles !== "NO_SMILES");
+      setHasValidSmallMolecules(validSmallMolecules.length > 0);
+
+      if (validSmallMolecules.length > 0) {
+        setReactionSMILES(createReactionSMILES(reactantIds, productIds, smallMolecules));
+      }
     });
   }, [data.reactants, data.products]);
 
@@ -116,7 +123,7 @@ export default function ReactionForm({ context }: FormViewProps<Reaction>) {
       locked={locked}
     >
       {/* Visual reaction representation */}
-      {reactionSMILES.length > 0 && (
+      {reactionSMILES.length > 0 && hasValidSmallMolecules && (
         <ReactionDrawerContainer
           className="mb-10"
           smilesStr={reactionSMILES}


### PR DESCRIPTION
This pull request introduces significant improvements to keyboard shortcut handling and file menu functionality, adds new document management features, and enhances code clarity with better documentation and refactoring. The main focus is on centralizing keyboard shortcut logic, supporting new and close document actions, and ensuring consistent behavior across the app.

**Keyboard shortcut and file menu enhancements:**

* Centralized the handling of file-related keyboard shortcuts (open, save, export, new, close) in the `useFileMenuShortcuts` hook, now supporting new document creation (`Cmd/Ctrl+N`) and closing the app window (`Cmd/Ctrl+W`). The hook also provides default behaviors and notification handling, improving maintainability and user feedback. [[1]](diffhunk://#diff-37dcb95f5df3eade45825cacbd6c4d4fa7474f3f908b384e424abade70c8a851R83-R87) [[2]](diffhunk://#diff-37dcb95f5df3eade45825cacbd6c4d4fa7474f3f908b384e424abade70c8a851R96-R132) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R91-R105) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R55-R63)
* Updated the `FileMenu` component to include "New Document" and "Close Suite" menu items, with corresponding handlers and keyboard shortcuts, and refactored the menu structure for clarity and consistency. [[1]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eR195-R206) [[2]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eL211-R245) [[3]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eR286-R293) [[4]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eL237-R260) [[5]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eR21-R22) [[6]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eR132-R134) [[7]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eL2-R9)

**Navigation and state management:**

* Integrated React Router's `useNavigate` and Tauri's `getCurrentWebviewWindow` throughout the app for consistent navigation and window management, enabling actions like returning to the home page after creating a new document or closing the app window. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R8-R11) [[2]](diffhunk://#diff-c0bac92054da73a23b520d22a13f7024a8a4f867d93eeee79b7a23695debff7eL2-R9) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L24-R27)

**UI/UX improvements:**

* Updated the `MainMenu` component to highlight the current menu item based on the application's route, improving navigation clarity for users. [[1]](diffhunk://#diff-0fd9a5788d003946ac633fbb4e7067002665a5bcd29fc6ca6dd305f3ef2f14a6R76-R86) [[2]](diffhunk://#diff-0fd9a5788d003946ac633fbb4e7067002665a5bcd29fc6ca6dd305f3ef2f14a6R112)

**Code quality and documentation:**

* Added comprehensive JSDoc comments and inline documentation to the `QuantityForm` component, clarifying its API, props, and internal logic for future maintainability. [[1]](diffhunk://#diff-fa3ac76f3a552722512b07b3c001e646c5aa4f8e26bd46a842d555d3288c9e3cR13-R48) [[2]](diffhunk://#diff-fa3ac76f3a552722512b07b3c001e646c5aa4f8e26bd46a842d555d3288c9e3cR59-R70) [[3]](diffhunk://#diff-fa3ac76f3a552722512b07b3c001e646c5aa4f8e26bd46a842d555d3288c9e3cL50-R84) [[4]](diffhunk://#diff-fa3ac76f3a552722512b07b3c001e646c5aa4f8e26bd46a842d555d3288c9e3cR102) [[5]](diffhunk://#diff-fa3ac76f3a552722512b07b3c001e646c5aa4f8e26bd46a842d555d3288c9e3cL77-R132)
* Refactored and cleaned up callback usage in `MeasurementForm`, improving debugging and ensuring correct update handling. [[1]](diffhunk://#diff-81404f51b930a0eb1ea74559ade274d5c9a0a4837ddb4744bb929d5eba89f321L49-L55) [[2]](diffhunk://#diff-81404f51b930a0eb1ea74559ade274d5c9a0a4837ddb4744bb929d5eba89f321L88-R92) [[3]](diffhunk://#diff-81404f51b930a0eb1ea74559ade274d5c9a0a4837ddb4744bb929d5eba89f321L133-R131)

<img width="879" height="359" alt="image" src="https://github.com/user-attachments/assets/b6f8e09f-694b-4323-bb56-4baa9ef7d1c6" />

<p align="center">
<img width="307" height="264" alt="image" src="https://github.com/user-attachments/assets/dfa9d6a1-b364-4082-8859-44d00e0ad7c8" />
</p>
